### PR TITLE
Add pre-requirements to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # SamplePlugin
 Sample plugin for HeapStatsFXAnalyzer to use as template project.
 
+## Pre-Requirements
+You have to install HeapStatsFXAnalzer to maven local repository.
+```
+$ cd /path/to/HeapStatsFXAnalyzer
+$ mvn install
+```
+
 ## Build
 
  1. mvn package


### PR DESCRIPTION
SamplePlugin depends HeapStatsFXAnalyzer in pom.xml .
HeapStatsFXAnalyzer is not provided from maven central.

So I add `mvn install` for HeapStatsFXAnalyzer to install it to local repository.
